### PR TITLE
feat(component): add optional validators to properties

### DIFF
--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -212,10 +212,13 @@ class AppElement extends JoistElement implements OnPropChanges {
 You can also provide validation functions to proeprty decorators for runtime safety.
 
 ```TS
-import { component, JoistElement, property, get } from '@joist/component';
+import { component, JoistElement, property, get, PropValidator } from '@joist/component';
 
-const isString = (val: unknown) => typeof val === 'string';
-const isLongerThan = (length: number) => (val: string) => val.length > length;
+const isString: PropValidator = (val: unknown) => typeof val === 'string' ? null : {};
+const isLongerThan = (length: number): PropValidator => (val: string) =>
+  val.length > length
+    ? null
+    : { message: `Length should have been longer than ${length} but was ${val.length}` };
 
 @component()
 class MyElement extends JoistElement {

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -209,6 +209,21 @@ class AppElement extends JoistElement implements OnPropChanges {
 }
 ```
 
+You can also provide validation functions to proeprty decorators for runtime safety.
+
+```TS
+import { component, JoistElement, property, get } from '@joist/component';
+
+const isString = (val: unknown) => typeof val === 'string';
+const isLongerThan = (length: number) => (val: string) => val.length > length;
+
+@component()
+class MyElement extends JoistElement {
+  @property(isString, isLongerThan(2))
+  public hello = 'Hello World';
+}
+```
+
 ### Component Handlers
 
 Component handlers allow components to respond to actions in a components view.

--- a/packages/component/lib/property.ts
+++ b/packages/component/lib/property.ts
@@ -1,6 +1,10 @@
 import { PropChange } from './lifecycle';
 
-export type PropValidator = (val: any) => boolean;
+export interface PropEValidationError {
+  message?: string;
+}
+
+export type PropValidator = (val: any) => null | PropEValidationError;
 
 export function property(...validators: PropValidator[]) {
   return function (target: any, key: string) {
@@ -11,8 +15,13 @@ export function property(...validators: PropValidator[]) {
       set(val) {
         if (validators.length) {
           validators.forEach((validator) => {
-            if (!validator(val)) {
-              throw new Error(`Validation failed when assigning ${val} to key ${key}`);
+            const res = validator(val);
+            if (res !== null) {
+              throw new Error(
+                `Validation failed when assigning ${val} to key ${key}.${
+                  res.message ? ' ' + res.message : ''
+                }`
+              );
             }
           });
         }

--- a/packages/component/lib/property.ts
+++ b/packages/component/lib/property.ts
@@ -1,12 +1,22 @@
 import { PropChange } from './lifecycle';
 
-export function property() {
+export type PropValidator = (val: any) => boolean;
+
+export function property(...validators: PropValidator[]) {
   return function (target: any, key: string) {
     const valueKey = `__prop__${key}__value`;
     const initKey = `__prop__${key}__initialized`;
 
     Object.defineProperty(target, key, {
       set(val) {
+        if (validators.length) {
+          validators.forEach((validator) => {
+            if (!validator(val)) {
+              throw new Error(`Validation failed when assigning ${val} to key ${key}`);
+            }
+          });
+        }
+
         if (this.onPropChanges) {
           const oldValue = this[key];
 

--- a/packages/component/lib/property.ts
+++ b/packages/component/lib/property.ts
@@ -1,10 +1,10 @@
 import { PropChange } from './lifecycle';
 
-export interface PropEValidationError {
+export interface PropValidationError {
   message?: string;
 }
 
-export type PropValidator = (val: any) => null | PropEValidationError;
+export type PropValidator = (val: any) => null | PropValidationError;
 
 export function property(...validators: PropValidator[]) {
   return function (target: any, key: string) {

--- a/packages/component/lib/propety.spec.ts
+++ b/packages/component/lib/propety.spec.ts
@@ -25,4 +25,32 @@ describe('property', () => {
       new PropChange('hello', 'Goodbye World', false, 'Hello World'),
     ]);
   });
+
+  it('should throw and error if the validtor returns false', () => {
+    class MyElement {
+      @property((val) => typeof val === 'string')
+      public hello: any = 'Hello World';
+    }
+
+    const el = new MyElement();
+
+    expect(() => (el.hello = 0)).toThrowError(`Validation failed when assigning 0 to key hello`);
+  });
+
+  it('should throw and error if ALL validators do not return true', () => {
+    const isString = (val: unknown) => typeof val === 'string';
+    const isLongerThan = (length: number) => (val: string) => val.length > length;
+
+    class MyElement {
+      @property(isString, isLongerThan(2))
+      public hello: any = 'Hello World';
+    }
+
+    const el = new MyElement();
+
+    expect(() => (el.hello = 0)).toThrowError(`Validation failed when assigning 0 to key hello`);
+    expect(() => (el.hello = 'He')).toThrowError(
+      `Validation failed when assigning He to key hello`
+    );
+  });
 });

--- a/packages/component/main.ts
+++ b/packages/component/main.ts
@@ -1,7 +1,7 @@
 export { defineEnvironment, clearEnvironment, getEnvironmentRef } from './lib/environment';
 export { State } from './lib/state';
 export { handle } from './lib/handle';
-export { property } from './lib/property';
+export { property, PropValidator, PropValidationError } from './lib/property';
 export { component, ComponentDef, RenderCtx, RenderDef, getComponentDef } from './lib/component';
 export { JoistElement, InjectorBase, get, withInjector } from './lib/element';
 export {


### PR DESCRIPTION
closes #249 

@Nevraeka do you think this is a good idea? or is it overkill? I can see this being useful but don't want to just throw things in that aren't necessary. But I am thinking that if you distributed widget type components it would be nice to have a declarative way to handle these sorts of errors.
