### PR TITLE
feat(di): make it hierarchical again.

### DIFF
--- a/integration/mixed/src/todo-card.element.ts
+++ b/integration/mixed/src/todo-card.element.ts
@@ -5,6 +5,7 @@ import { render, html } from 'lit-html';
 import classNames from 'classnames';
 
 import { Todo, TodoStatus, TodoService } from './todo.service';
+import { Injected } from 'packages/di/target/build/lib/injectable';
 
 @injectable
 @observable
@@ -46,7 +47,7 @@ export class TodoCard extends HTMLElement implements OnPropertyChanged {
 
   @observe todo?: Todo;
 
-  constructor(private service: TodoService) {
+  constructor(private service: Injected<TodoService>) {
     super();
 
     this.attachShadow({ mode: 'open' });
@@ -78,7 +79,7 @@ export class TodoCard extends HTMLElement implements OnPropertyChanged {
       </button>
 
       <button class="complete" @click="${() => this.dispatchEvent(new Event('complete_todo'))}">
-        ${this.service.getStatusText(this.todo)}
+        ${this.service().getStatusText(this.todo)}
       </button>
     `;
   }

--- a/integration/own/src/todo-form.element.ts
+++ b/integration/own/src/todo-form.element.ts
@@ -1,5 +1,6 @@
 import { injectable } from '@joist/di';
 import { styled, css } from '@joist/styled';
+import { Injected } from 'packages/di/target/build/lib/injectable';
 
 import { TodoService, Todo, TodoStatus } from './todo.service';
 
@@ -65,7 +66,7 @@ export class TodoForm extends HTMLElement {
   private root = this.attachShadow({ mode: 'open' });
   private input: HTMLInputElement | null = null;
 
-  constructor(private todo: TodoService) {
+  constructor(private todo: Injected<TodoService>) {
     super();
   }
 
@@ -85,7 +86,7 @@ export class TodoForm extends HTMLElement {
     const todo = this.input!.value;
 
     if (todo.length) {
-      this.todo.addTodo(new Todo(todo, TodoStatus.Active));
+      this.todo().addTodo(new Todo(todo, TodoStatus.Active));
 
       this.input!.value = '';
     }

--- a/integration/own/src/todo-list.element.ts
+++ b/integration/own/src/todo-list.element.ts
@@ -2,6 +2,7 @@ import { injectable } from '@joist/di';
 import { observable, observe, OnPropertyChanged } from '@joist/observable';
 import { styled, css } from '@joist/styled';
 import { render, html } from 'lit-html';
+import { Injected } from 'packages/di/target/build/lib/injectable';
 
 import { TodoService, Todo, TodoStatus } from './todo.service';
 
@@ -55,14 +56,14 @@ export class TodoList extends HTMLElement implements OnPropertyChanged {
   @observe private todos: Todo[] = [];
   @observe private totalActive = 0;
 
-  constructor(private todo: TodoService) {
+  constructor(private todo: Injected<TodoService>) {
     super();
 
-    this.todos = this.todo.todos;
+    this.todos = this.todo().todos;
     this.totalActive = this.getActiveTodoCount();
 
-    this.todo.addEventListener('todochange', () => {
-      this.todos = this.todo.todos;
+    this.todo().addEventListener('todochange', () => {
+      this.todos = this.todo().todos;
       this.totalActive = this.getActiveTodoCount();
     });
 
@@ -84,7 +85,7 @@ export class TodoList extends HTMLElement implements OnPropertyChanged {
           return html`
             <todo-card
               .todo=${todo}
-              @remove=${() => this.todo.removeTodo(i)}
+              @remove=${() => this.todo().removeTodo(i)}
               @complete=${() => this.completeTodo(i)}
             ></todo-card>
           `;
@@ -102,15 +103,15 @@ export class TodoList extends HTMLElement implements OnPropertyChanged {
   }
 
   private getActiveTodoCount(): number {
-    return this.todo.todos
-      .filter((todo) => todo.status === TodoStatus.Active)
+    return this.todo()
+      .todos.filter((todo) => todo.status === TodoStatus.Active)
       .reduce<number>((total) => total + 1, 0);
   }
 
   private completeTodo(i: number) {
-    const todo = this.todo.todos[i];
+    const todo = this.todo().todos[i];
 
-    return this.todo.updateTodo(i, {
+    return this.todo().updateTodo(i, {
       status: todo.status === TodoStatus.Active ? TodoStatus.Completed : TodoStatus.Active,
     });
   }

--- a/integration/own/src/todo.service.ts
+++ b/integration/own/src/todo.service.ts
@@ -1,4 +1,4 @@
-import { service, injectable } from '@joist/di';
+import { service } from '@joist/di';
 import { observable, observe, OnPropertyChanged } from '@joist/observable';
 
 import { AppStorage } from './storage.service';
@@ -20,7 +20,6 @@ export class TodoChangeEvent extends Event {
 
 @service
 @observable
-@injectable
 export class TodoService extends EventTarget implements OnPropertyChanged {
   static inject = [AppStorage];
 

--- a/packages/di/lib/environment.test.ts
+++ b/packages/di/lib/environment.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@open-wc/testing';
 
 import { getEnvironmentRef, clearEnvironment } from './environment';
-import { injectable } from './injectable';
+import { injectable, Injected } from './injectable';
 import { Injector } from './injector';
 import { service } from './service';
 
@@ -20,7 +20,7 @@ describe('environment', () => {
     class MyElement extends HTMLElement {
       static inject = [MyService];
 
-      constructor(public my: MyService) {
+      constructor(public my: Injected<MyService>) {
         super();
       }
     }
@@ -29,6 +29,6 @@ describe('environment', () => {
 
     const el = document.createElement('env-1') as MyElement;
 
-    expect(el.my).to.equal(getEnvironmentRef().get(MyService));
+    expect(el.my()).to.equal(getEnvironmentRef().get(MyService));
   });
 });

--- a/packages/di/tsconfig.json
+++ b/packages/di/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "files": ["lib.ts"],
-  "include": ["lib"],
+  "include": ["lib", "typings.d.ts"],
   "exclude": ["target"]
 }

--- a/packages/di/typings.d.ts
+++ b/packages/di/typings.d.ts
@@ -1,0 +1,4 @@
+declare interface HTMLElement {
+  connectedCallback?(): void;
+  disconnectedCallback?(): void;
+}


### PR DESCRIPTION
reimplements the DI hierarchy when using custom elements. Instead of the full constructed object the injector passes the element `Injected<T>` which is a function. When called this function will instantiate the service.

```TS
@injectable
class Foo extends HTMLElement {
  constructor(private foo: Injected<Foo>) {}

  connectedCallback() {
    console.log(this.foo().something())
  }
}
```