### PR TITLE
move element injection code to the element package

### DIFF
--- a/integration/todo/src/elements/todo-form.element.ts
+++ b/integration/todo/src/elements/todo-form.element.ts
@@ -1,9 +1,8 @@
-import { inject, injectable } from '@joist/di';
+import { inject } from '@joist/di';
 import { css, html, shadow, listen, tagName, element } from '@joist/element';
 
 import { TodoService, Todo } from '../services/todo.service.js';
 
-@injectable
 @element
 export class TodoFormElement extends HTMLElement {
   @tagName static tagName = 'todo-form';

--- a/integration/todo/src/elements/todo-list-footer.element.ts
+++ b/integration/todo/src/elements/todo-list-footer.element.ts
@@ -1,5 +1,5 @@
 import { css, html, shadow, tagName, element } from '@joist/element';
-import { inject, injectable } from '@joist/di';
+import { inject } from '@joist/di';
 
 import { TodoService } from '../services/todo.service.js';
 
@@ -12,7 +12,6 @@ class PluralRules extends Intl.PluralRules {
   static service = true;
 }
 
-@injectable
 @element
 export class TodoListFooterElement extends HTMLElement {
   @tagName static tagName = 'todo-list-footer';

--- a/integration/todo/src/elements/todo-list.element.ts
+++ b/integration/todo/src/elements/todo-list.element.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from '@joist/di';
+import { inject } from '@joist/di';
 import { css, html, shadow, listen, tagName, element } from '@joist/element';
 
 import {
@@ -9,7 +9,6 @@ import {
 } from '../services/todo.service.js';
 import { createTodoCard, TodoCardElement } from './todo-card.element.js';
 
-@injectable
 @element
 export class TodoListElement extends HTMLElement {
   @tagName static tagName = 'todo-list';

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -207,69 +207,6 @@ InjectorB would given a NEW instances created from RootInjector.
 This is because InjectorB does not fall under InjectorD.
 This behavior allows for services to be "scoped" within a certain branch of the tree. This is what allows for the scoped custom element behavior defined in the next section.
 
-## Custom Elements:
-
-Joist is built to work with custom elements. Since the document is a tree we can search up that tree for providers.
-
-```TS
-import { injectable, inject } from '@joist/di';
-
-class Colors {
-  primary = 'red';
-  secodnary = 'green';
-}
-
-@injectable
-class ColorCtx extends HTMLElement {
-  // services can be scoped to a particular injectable
-  static providers = [
-    {
-      provide: Colors,
-      use: class implements Colors {
-        primary = 'orange';
-        secondary = 'purple';
-      },
-    },
-  ]
-}
-
-@injectable
-class MyElement extends HTMLElement {
-  #colors = inject(Colors);
-
-  connectedCallback() {
-    const { primary } = this.#colors();
-
-    this.style.background = primary;
-  }
-}
-
-// Note: To use parent providers, the parent elements need to be defined first in correct order!
-customElements.define('color-ctx', ColorCtx);
-customElements.define('my-element', MyElement);
-```
-
-```HTML
-<!-- Default Colors -->
-<my-element></my-element>
-
-<!-- Special color ctx -->
-<color-ctx>
-  <my-element></my-element>
-</color-ctx>
-```
-
-## Environment
-
-When using @joist/di with custom elements a default root injector is created dubbed 'environment'. This is the injector that all other injectors will eventually stop at.
-If you need to define something in this environment you can do so with the `defineEnvironment` method.
-
-```ts
-import { defineEnvironment } from '@joist/di';
-
-defineEnvironment([{ provide: MyService, use: SomeOtherService }]);
-```
-
 #### No decorators no problem:
 
 While this library is built with decorators in mind it is designed so that it can be used without them.

--- a/packages/di/src/lib.ts
+++ b/packages/di/src/lib.ts
@@ -1,5 +1,4 @@
 export { Injector } from './lib/injector.js';
 export { Provider, ConstructableToken, StaticToken } from './lib/provider.js';
-export { injectable } from './lib/injectable.js';
+export { injectable, INJECTABLE_MAP } from './lib/injectable.js';
 export { inject, Injected } from './lib/inject.js';
-export { defineEnvironment, clearEnvironment } from './lib/environment.js';

--- a/packages/di/src/lib/inject.ts
+++ b/packages/di/src/lib/inject.ts
@@ -1,5 +1,5 @@
 import { ConstructableToken } from './provider.js';
-import { INJECTABLES } from './injectable.js';
+import { INJECTABLE_MAP } from './injectable.js';
 
 export type Injected<T> = () => T;
 
@@ -7,7 +7,7 @@ export function inject<This extends object, T extends object>(
   token: ConstructableToken<T>
 ): Injected<T> {
   return function (this: This) {
-    const injector = INJECTABLES.get(this);
+    const injector = INJECTABLE_MAP.get(this);
 
     if (injector === undefined) {
       const name = Object.getPrototypeOf(this.constructor).name;

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -1,26 +1,26 @@
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect } from '@open-wc/testing';
 
 import { injectable } from './injectable.js';
 import { inject } from './inject.js';
 import { Injector } from './injector.js';
 
 describe('@injectable()', () => {
-  it('should allow a custom element to be injected with deps', () => {
-    class Foo {}
-    class Bar {}
+  // it('should allow a custom element to be injected with deps', () => {
+  //   class Foo {}
+  //   class Bar {}
 
-    @injectable
-    class MyElement extends HTMLElement {
-      foo = inject(Foo);
-      bar = inject(Bar);
-    }
+  //   @injectable
+  //   class MyElement extends HTMLElement {
+  //     foo = inject(Foo);
+  //     bar = inject(Bar);
+  //   }
 
-    customElements.define('injectable-1', MyElement);
+  //   customElements.define('injectable-1', MyElement);
 
-    const el = document.createElement('injectable-1') as MyElement;
+  //   const el = document.createElement('injectable-1') as MyElement;
 
-    expect(el.foo()).to.be.instanceOf(Foo);
-  });
+  //   expect(el.foo()).to.be.instanceOf(Foo);
+  // });
 
   it('should locally override a provider', () => {
     class Foo {}
@@ -40,7 +40,7 @@ describe('@injectable()', () => {
     expect(el.foo()).to.be.instanceOf(Bar);
   });
 
-  it('should call the onInject lifecycle hook', () => {
+  it('should call the onInject lifecycle hook', (done) => {
     class A {}
 
     @injectable
@@ -49,96 +49,98 @@ describe('@injectable()', () => {
 
       onInject() {
         expect(this.a()).to.be.instanceOf(A);
+
+        done();
       }
     }
 
     new Injector().get(B);
   });
 
-  it('should handle parent HTML Injectors', async () => {
-    @injectable
-    class A {}
+  // it('should handle parent HTML Injectors', async () => {
+  //   @injectable
+  //   class A {}
 
-    const B = injectable(
-      class {
-        a = inject(A);
-      }
-    );
+  //   const B = injectable(
+  //     class {
+  //       a = inject(A);
+  //     }
+  //   );
 
-    class AltA implements A {}
+  //   class AltA implements A {}
 
-    @injectable
-    class Parent extends HTMLElement {
-      static providers = [
-        { provide: B, use: B },
-        { provide: A, use: AltA }
-      ];
-    }
+  //   @injectable
+  //   class Parent extends HTMLElement {
+  //     static providers = [
+  //       { provide: B, use: B },
+  //       { provide: A, use: AltA }
+  //     ];
+  //   }
 
-    @injectable
-    class Child extends HTMLElement {
-      b = inject(B);
-    }
+  //   @injectable
+  //   class Child extends HTMLElement {
+  //     b = inject(B);
+  //   }
 
-    customElements.define('injectable-parent-1', Parent);
-    customElements.define('injectable-child-1', Child);
+  //   customElements.define('injectable-parent-1', Parent);
+  //   customElements.define('injectable-child-1', Child);
 
-    const el = await fixture(html`
-      <injectable-parent-1>
-        <injectable-child-1></injectable-child-1>
-      </injectable-parent-1>
-    `);
+  //   const el = await fixture(html`
+  //     <injectable-parent-1>
+  //       <injectable-child-1></injectable-child-1>
+  //     </injectable-parent-1>
+  //   `);
 
-    const child = el.querySelector<Child>('injectable-child-1')!;
+  //   const child = el.querySelector<Child>('injectable-child-1')!;
 
-    expect(child.b().a()).to.be.instanceOf(AltA);
-  });
+  //   expect(child.b().a()).to.be.instanceOf(AltA);
+  // });
 
-  it('should handle changing contexts', async () => {
-    class A {}
-    class AltA implements A {}
+  // it('should handle changing contexts', async () => {
+  //   class A {}
+  //   class AltA implements A {}
 
-    @injectable
-    class Ctx1 extends HTMLElement {
-      static providers = [{ provide: A, use: A }];
-    }
+  //   @injectable
+  //   class Ctx1 extends HTMLElement {
+  //     static providers = [{ provide: A, use: A }];
+  //   }
 
-    @injectable
-    class Ctx2 extends HTMLElement {
-      static providers = [{ provide: A, use: AltA }];
-    }
+  //   @injectable
+  //   class Ctx2 extends HTMLElement {
+  //     static providers = [{ provide: A, use: AltA }];
+  //   }
 
-    @injectable
-    class Child extends HTMLElement {
-      a = inject(A);
-    }
+  //   @injectable
+  //   class Child extends HTMLElement {
+  //     a = inject(A);
+  //   }
 
-    customElements.define('ctx-1', Ctx1);
-    customElements.define('ctx-2', Ctx2);
-    customElements.define('ctx-child', Child);
+  //   customElements.define('ctx-1', Ctx1);
+  //   customElements.define('ctx-2', Ctx2);
+  //   customElements.define('ctx-child', Child);
 
-    const el = await fixture(html`
-      <div>
-        <ctx-1>
-          <ctx-child></ctx-child>
-        </ctx-1>
+  //   const el = await fixture(html`
+  //     <div>
+  //       <ctx-1>
+  //         <ctx-child></ctx-child>
+  //       </ctx-1>
 
-        <ctx-2></ctx-2>
-      </div>
-    `);
+  //       <ctx-2></ctx-2>
+  //     </div>
+  //   `);
 
-    const ctx2 = el.querySelector('ctx-2')!;
+  //   const ctx2 = el.querySelector('ctx-2')!;
 
-    let child = el.querySelector<Child>('ctx-child')!;
+  //   let child = el.querySelector<Child>('ctx-child')!;
 
-    expect(child.a()).to.be.instanceOf(A);
+  //   expect(child.a()).to.be.instanceOf(A);
 
-    child.remove();
+  //   child.remove();
 
-    ctx2.append(child);
+  //   ctx2.append(child);
 
-    child = el.querySelector<Child>('ctx-child')!;
+  //   child = el.querySelector<Child>('ctx-child')!;
 
-    expect(child.a()).to.be.instanceOf(AltA);
-  });
+  //   expect(child.a()).to.be.instanceOf(AltA);
+  // });
 });

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -5,23 +5,6 @@ import { inject } from './inject.js';
 import { Injector } from './injector.js';
 
 describe('@injectable()', () => {
-  // it('should allow a custom element to be injected with deps', () => {
-  //   class Foo {}
-  //   class Bar {}
-
-  //   @injectable
-  //   class MyElement extends HTMLElement {
-  //     foo = inject(Foo);
-  //     bar = inject(Bar);
-  //   }
-
-  //   customElements.define('injectable-1', MyElement);
-
-  //   const el = document.createElement('injectable-1') as MyElement;
-
-  //   expect(el.foo()).to.be.instanceOf(Foo);
-  // });
-
   it('should locally override a provider', () => {
     class Foo {}
 
@@ -56,91 +39,4 @@ describe('@injectable()', () => {
 
     new Injector().get(B);
   });
-
-  // it('should handle parent HTML Injectors', async () => {
-  //   @injectable
-  //   class A {}
-
-  //   const B = injectable(
-  //     class {
-  //       a = inject(A);
-  //     }
-  //   );
-
-  //   class AltA implements A {}
-
-  //   @injectable
-  //   class Parent extends HTMLElement {
-  //     static providers = [
-  //       { provide: B, use: B },
-  //       { provide: A, use: AltA }
-  //     ];
-  //   }
-
-  //   @injectable
-  //   class Child extends HTMLElement {
-  //     b = inject(B);
-  //   }
-
-  //   customElements.define('injectable-parent-1', Parent);
-  //   customElements.define('injectable-child-1', Child);
-
-  //   const el = await fixture(html`
-  //     <injectable-parent-1>
-  //       <injectable-child-1></injectable-child-1>
-  //     </injectable-parent-1>
-  //   `);
-
-  //   const child = el.querySelector<Child>('injectable-child-1')!;
-
-  //   expect(child.b().a()).to.be.instanceOf(AltA);
-  // });
-
-  // it('should handle changing contexts', async () => {
-  //   class A {}
-  //   class AltA implements A {}
-
-  //   @injectable
-  //   class Ctx1 extends HTMLElement {
-  //     static providers = [{ provide: A, use: A }];
-  //   }
-
-  //   @injectable
-  //   class Ctx2 extends HTMLElement {
-  //     static providers = [{ provide: A, use: AltA }];
-  //   }
-
-  //   @injectable
-  //   class Child extends HTMLElement {
-  //     a = inject(A);
-  //   }
-
-  //   customElements.define('ctx-1', Ctx1);
-  //   customElements.define('ctx-2', Ctx2);
-  //   customElements.define('ctx-child', Child);
-
-  //   const el = await fixture(html`
-  //     <div>
-  //       <ctx-1>
-  //         <ctx-child></ctx-child>
-  //       </ctx-1>
-
-  //       <ctx-2></ctx-2>
-  //     </div>
-  //   `);
-
-  //   const ctx2 = el.querySelector('ctx-2')!;
-
-  //   let child = el.querySelector<Child>('ctx-child')!;
-
-  //   expect(child.a()).to.be.instanceOf(A);
-
-  //   child.remove();
-
-  //   ctx2.append(child);
-
-  //   child = el.querySelector<Child>('ctx-child')!;
-
-  //   expect(child.a()).to.be.instanceOf(AltA);
-  // });
 });

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -1,4 +1,4 @@
-import { INJECTABLES } from './injectable.js';
+import { INJECTABLE_MAP } from './injectable.js';
 import { InjectionToken, Provider, StaticToken } from './provider.js';
 
 /**
@@ -89,7 +89,7 @@ export class Injector {
      * Only values that are objects are able to have associated injectors
      */
     if (typeof instance === 'object' && instance !== null) {
-      const injector = INJECTABLES.get(instance);
+      const injector = INJECTABLE_MAP.get(instance);
 
       if (injector) {
         /**

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -8,7 +8,7 @@ Create a shadow root and apply styles and html as defined
 npm i @joist/element
 ```
 
-#### Example:
+## Example:
 
 ```TS
 import { tagName, shadow, css, html, attr, listen, element } from '@joist/element';
@@ -39,4 +39,68 @@ export class MyElement extends HTMLElement {
     console.log('clicked!')
   }
 }
+```
+
+## Dependency Injection:
+
+Joist dependency injejection is built to work with custom elements. Any custom element class that is decorated with `@element` will be allowed to use the `inject()` function.
+
+```TS
+import { element } from "@joist/element";
+import { injectable, inject } from '@joist/di';
+
+class Colors {
+  primary = 'red';
+  secodnary = 'green';
+}
+
+@element
+class ColorCtx extends HTMLElement {
+  // services can be scoped to a particular injectable
+  static providers = [
+    {
+      provide: Colors,
+      use: class implements Colors {
+        primary = 'orange';
+        secondary = 'purple';
+      },
+    },
+  ]
+}
+
+@element
+class MyElement extends HTMLElement {
+  #colors = inject(Colors);
+
+  connectedCallback() {
+    const { primary } = this.#colors();
+
+    this.style.background = primary;
+  }
+}
+
+// Note: To use parent providers, the parent elements need to be defined first in correct order!
+customElements.define('color-ctx', ColorCtx);
+customElements.define('my-element', MyElement);
+```
+
+```HTML
+<!-- Default Colors -->
+<my-element></my-element>
+
+<!-- Special color ctx -->
+<color-ctx>
+  <my-element></my-element>
+</color-ctx>
+```
+
+## Environment
+
+When using @joist/di with custom elements a default root injector is created dubbed 'environment'. This is the injector that all other injectors will eventually stop at.
+If you need to define something in this environment you can do so with the `defineEnvironment` method.
+
+```ts
+import { defineEnvironment } from '@joist/di';
+
+defineEnvironment([{ provide: MyService, use: SomeOtherService }]);
 ```

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -52,6 +52,9 @@
       "output": [
         "target/**",
         "tsconfig.tsbuildinfo"
+      ],
+      "dependencies": [
+        "../di:build"
       ]
     },
     "test": {

--- a/packages/element/src/lib.ts
+++ b/packages/element/src/lib.ts
@@ -5,3 +5,4 @@ export { attr } from './lib/attr.js';
 export { listen } from './lib/listen.js';
 export { tagName } from './lib/tag-name.js';
 export { element } from './lib/element.js';
+export { environment, defineEnvironment } from './lib/environment.js';

--- a/packages/element/src/lib/element.test.ts
+++ b/packages/element/src/lib/element.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import { inject, injectable } from '@joist/di';
 
 import { attr } from './attr.js';
 import { element } from './element.js';
@@ -20,5 +21,91 @@ describe('@element()', () => {
     expect(el.getAttribute('value1')).to.equal('hello');
     expect(el.getAttribute('value2')).to.equal('0');
     expect(el.getAttribute('value3')).to.equal('');
+  });
+
+  it('should handle parent HTML Injectors', async () => {
+    @injectable
+    class A {}
+
+    @injectable
+    class B {
+      a = inject(A);
+    }
+
+    class AltA implements A {}
+
+    @element
+    class Parent extends HTMLElement {
+      static providers = [
+        { provide: B, use: B },
+        { provide: A, use: AltA }
+      ];
+    }
+
+    @element
+    class Child extends HTMLElement {
+      b = inject(B);
+    }
+
+    customElements.define('injectable-parent-1', Parent);
+    customElements.define('injectable-child-1', Child);
+
+    const el = await fixture(html`
+      <injectable-parent-1>
+        <injectable-child-1></injectable-child-1>
+      </injectable-parent-1>
+    `);
+
+    const child = el.querySelector<Child>('injectable-child-1')!;
+
+    expect(child.b().a()).to.be.instanceOf(AltA);
+  });
+
+  it('should handle changing contexts', async () => {
+    class A {}
+    class AltA implements A {}
+
+    @element
+    class Ctx1 extends HTMLElement {
+      static providers = [{ provide: A, use: A }];
+    }
+
+    @element
+    class Ctx2 extends HTMLElement {
+      static providers = [{ provide: A, use: AltA }];
+    }
+
+    @element
+    class Child extends HTMLElement {
+      a = inject(A);
+    }
+
+    customElements.define('ctx-1', Ctx1);
+    customElements.define('ctx-2', Ctx2);
+    customElements.define('ctx-child', Child);
+
+    const el = await fixture(html`
+      <div>
+        <ctx-1>
+          <ctx-child></ctx-child>
+        </ctx-1>
+
+        <ctx-2></ctx-2>
+      </div>
+    `);
+
+    const ctx2 = el.querySelector('ctx-2')!;
+
+    let child = el.querySelector<Child>('ctx-child')!;
+
+    expect(child.a()).to.be.instanceOf(A);
+
+    child.remove();
+
+    ctx2.append(child);
+
+    child = el.querySelector<Child>('ctx-child')!;
+
+    expect(child.a()).to.be.instanceOf(AltA);
   });
 });

--- a/packages/element/src/lib/environment.test.ts
+++ b/packages/element/src/lib/environment.test.ts
@@ -1,9 +1,8 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import { Injector, injectable, inject } from '@joist/di';
 
-import { Injector } from './injector.js';
 import { environment, clearEnvironment } from './environment.js';
-import { injectable } from './injectable.js';
-import { inject } from './inject.js';
+import { element } from './element.js';
 
 describe('environment', () => {
   afterEach(clearEnvironment);
@@ -16,7 +15,7 @@ describe('environment', () => {
     @injectable
     class MyService {}
 
-    @injectable
+    @element
     class MyElement extends HTMLElement {
       my = inject(MyService);
     }

--- a/packages/element/src/lib/environment.ts
+++ b/packages/element/src/lib/environment.ts
@@ -1,5 +1,4 @@
-import { Injector } from './injector.js';
-import { Provider } from './provider.js';
+import { Injector, Provider } from '@joist/di';
 
 let rootInjector: Injector;
 


### PR DESCRIPTION
This would technically be a breaking change and would mean that when wanting to use dependency injection with OTHER web component library you would have to pull in @joist/element which might not feel ideal.

for example using the injector with lit-element.

Another option COULD be to move the custom element injector stuff into its own sub path? At the end of the day it may make the most sense to keep it as is so that defining injectable services is the same regardless of the class type.

What could make sense it to ALSO make all @element declared custom elements ALSO be injectable so folks don't have to add two decorators

closes #996 

```ts
@customElement
@element
export class MyElement extends HTMLElement {}
```