### PR TITLE
Lifecycle

### DIFF
--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -11,6 +11,7 @@ Allows you to inject services into other class instances (including custom eleme
 - [Factories](#factories)
 - [Static Tokens](#static-tokens)
 - [Testing](#testing)
+- [LifeCycle](#life-cycle)
 - [Parent/Child Relationship](#parentchild-relationship)
 - [Custom Elements](#custom-elements)
 - [Environment](#environment)
@@ -210,6 +211,22 @@ const testApp = new Injector([
 
 // our test instance will be using our mock when making http requests
 const api = testApp.get(ApiService);
+```
+
+## Life Cycle
+
+To helo provide more information to services that are being created, joist will call several life cycle hooks as services are created. These hooks are defined using the provided symbols so there is no risk of naming colisions.
+
+```ts
+class MyService {
+  [LifeCycle.onInit]() {
+    // called the first time a service is created. (not pulled from cache)
+  }
+
+  [LifeCycle.onInject]() {
+    // called every time a service is returned, whether it is from cache or not
+  }
+}
 ```
 
 ## Parent/Child relationship

--- a/packages/di/src/lib.ts
+++ b/packages/di/src/lib.ts
@@ -3,3 +3,4 @@ export { Provider, ConstructableToken, StaticToken, token } from './lib/provider
 export { injectable, INJECTABLE_MAP } from './lib/injectable.js';
 export { inject, Injected } from './lib/inject.js';
 export { defineEnvironment, clearEnvironment } from './lib/environment.js';
+export { LifeCycle } from './lib/lifecycle.js';

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -42,7 +42,7 @@ describe('inject', () => {
       const error = err as Error;
 
       expect(error.message).to.equal(
-        `BarService is either not injectable or a service is being called in the constructor. \n Either add the @injectable to your class or use the onInject callback method.`
+        `BarService is either not injectable or a service is being called in the constructor. \n Either add the @injectable to your class or use the [LifeCycle.onInject] callback method.`
       );
     }
   });

--- a/packages/di/src/lib/inject.ts
+++ b/packages/di/src/lib/inject.ts
@@ -13,7 +13,7 @@ export function inject<This extends object, T extends object>(
       const name = Object.getPrototypeOf(this.constructor).name;
 
       throw new Error(
-        `${name} is either not injectable or a service is being called in the constructor. \n Either add the @injectable to your class or use the onInject callback method.`
+        `${name} is either not injectable or a service is being called in the constructor. \n Either add the @injectable to your class or use the [LifeCycle.onInject] callback method.`
       );
     }
 

--- a/packages/di/src/lib/lifecycle.test.ts
+++ b/packages/di/src/lib/lifecycle.test.ts
@@ -1,0 +1,61 @@
+import { expect } from '@open-wc/testing';
+import { Injector } from './injector.js';
+import { LifeCycle } from './lifecycle.js';
+import { injectable } from './injectable';
+
+describe('LifeCycle', () => {
+  it('should call onInit and onInject when a service is first created', () => {
+    const i = new Injector();
+
+    const res = {
+      onInit: 0,
+      onInject: 0
+    };
+
+    @injectable
+    class MyService {
+      [LifeCycle.onInit]() {
+        res.onInit++;
+      }
+
+      [LifeCycle.onInject]() {
+        res.onInject++;
+      }
+    }
+
+    i.inject(MyService);
+
+    expect(res).to.deep.equal({
+      onInit: 1,
+      onInject: 1
+    });
+  });
+
+  it('should call onInject any time a service is returned', () => {
+    const i = new Injector();
+
+    const res = {
+      onInit: 0,
+      onInject: 0
+    };
+
+    @injectable
+    class MyService {
+      [LifeCycle.onInit]() {
+        res.onInit++;
+      }
+
+      [LifeCycle.onInject]() {
+        res.onInject++;
+      }
+    }
+
+    i.inject(MyService);
+    i.inject(MyService);
+
+    expect(res).to.deep.equal({
+      onInit: 1,
+      onInject: 2
+    });
+  });
+});

--- a/packages/di/src/lib/lifecycle.test.ts
+++ b/packages/di/src/lib/lifecycle.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@open-wc/testing';
 import { Injector } from './injector.js';
 import { LifeCycle } from './lifecycle.js';
 import { injectable } from './injectable';
+import { inject } from './inject.js';
 
 describe('LifeCycle', () => {
   it('should call onInit and onInject when a service is first created', () => {
@@ -51,6 +52,39 @@ describe('LifeCycle', () => {
     }
 
     i.inject(MyService);
+    i.inject(MyService);
+
+    expect(res).to.deep.equal({
+      onInit: 1,
+      onInject: 2
+    });
+  });
+
+  it('should call onInject and on init when injected from another service', () => {
+    const i = new Injector();
+
+    const res = {
+      onInit: 0,
+      onInject: 0
+    };
+
+    @injectable
+    class MyService {
+      [LifeCycle.onInit]() {
+        res.onInit++;
+      }
+
+      [LifeCycle.onInject]() {
+        res.onInject++;
+      }
+    }
+
+    @injectable
+    class MyApp {
+      service = inject(MyService);
+    }
+
+    i.inject(MyApp).service();
     i.inject(MyService);
 
     expect(res).to.deep.equal({

--- a/packages/di/src/lib/lifecycle.ts
+++ b/packages/di/src/lib/lifecycle.ts
@@ -1,0 +1,4 @@
+export const LifeCycle = {
+  onInit: Symbol('OnInit'),
+  onInject: Symbol('OnInject')
+} as const;


### PR DESCRIPTION
This PR fixes some unclear behavior with the onInject lifecycle hook and adds an onInit hook. onInit is called once and onInject is called each time the service is requested.

closes #1009 