### PR TITLE
Fix type issue with inject function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joist",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joist",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/**"

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@open-wc/testing';
 import { inject } from './inject.js';
 import { injectable } from './injectable.js';
 import { Injector } from './injector.js';
-import { StaticToken, token } from './provider.js';
+import { StaticToken } from './provider.js';
 
 describe('inject', () => {
   it('should work', () => {
@@ -71,7 +71,7 @@ describe('inject', () => {
   });
 
   it('should inject a static toke', () => {
-    const TOKEN = new StaticToken('test', () => 'Hello World')
+    const TOKEN = new StaticToken('test', () => 'Hello World');
 
     @injectable
     class HelloWorld extends HTMLElement {
@@ -82,5 +82,4 @@ describe('inject', () => {
 
     expect(new HelloWorld().hello()).to.be('Hello World');
   });
-
 });

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -78,8 +78,8 @@ describe('inject', () => {
       hello = inject(TOKEN);
     }
 
-    customElements.define('inject-1', HelloWorld);
+    customElements.define('inject-2', HelloWorld);
 
-    expect(new HelloWorld().hello()).to.be('Hello World');
+    expect(new HelloWorld().hello()).to.equal('Hello World');
   });
 });

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -78,8 +78,6 @@ describe('inject', () => {
       hello = inject(TOKEN);
     }
 
-    const app = new Injector();
-
-    expect(app.get(HelloWorld).hello()).to.equal('Hello World');
+    expect(new HelloWorld().hello()).to.equal('Hello World');
   });
 });

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -3,6 +3,7 @@ import { expect } from '@open-wc/testing';
 import { inject } from './inject.js';
 import { injectable } from './injectable.js';
 import { Injector } from './injector.js';
+import { StaticToken, token } from './provider.js';
 
 describe('inject', () => {
   it('should work', () => {
@@ -68,4 +69,18 @@ describe('inject', () => {
 
     expect(parent.inject(BarService).foo().value).to.equal('100');
   });
+
+  it('should inject a static toke', () => {
+    const TOKEN = new StaticToken('test', () => 'Hello World')
+
+    @injectable
+    class HelloWorld extends HTMLElement {
+      hello = inject(TOKEN);
+    }
+
+    customElements.define('inject-1', HelloWorld);
+
+    expect(new HelloWorld().hello()).to.be('Hello World');
+  });
+
 });

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -70,16 +70,16 @@ describe('inject', () => {
     expect(parent.inject(BarService).foo().value).to.equal('100');
   });
 
-  it('should inject a static toke', () => {
+  it('should inject a static token', () => {
     const TOKEN = new StaticToken('test', () => 'Hello World');
 
     @injectable
-    class HelloWorld extends HTMLElement {
+    class HelloWorld {
       hello = inject(TOKEN);
     }
 
-    customElements.define('inject-2', HelloWorld);
+    const app = new Injector();
 
-    expect(new HelloWorld().hello()).to.equal('Hello World');
+    expect(app.get(HelloWorld).hello()).to.equal('Hello World');
   });
 });

--- a/packages/di/src/lib/inject.ts
+++ b/packages/di/src/lib/inject.ts
@@ -1,10 +1,10 @@
-import { ConstructableToken } from './provider.js';
+import { InjectionToken } from './provider.js';
 import { INJECTABLE_MAP } from './injectable.js';
 
 export type Injected<T> = () => T;
 
-export function inject<This extends object, T extends object>(
-  token: ConstructableToken<T>
+export function inject<This extends object, T>(
+  token: InjectionToken<T>
 ): Injected<T> {
   return function (this: This) {
     const injector = INJECTABLE_MAP.get(this);


### PR DESCRIPTION
This PR fixes an issue what was missed when adding types to the `inject()` function used in services. This fixes the issue and adds a test to make sure it doesn't happen again