### PR TITLE
Fix injectable decorator: pass constructor arguments to super (#1072)

### DIFF
--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -4,8 +4,8 @@ import { environment } from './environment.js';
 
 export function injectable<T extends ConstructableToken<any>>(Base: T, _?: unknown) {
   return class InjectableNode extends Base {
-    constructor(..._: any[]) {
-      super();
+    constructor(...args: any[]) {
+      super(...args);
 
       // Define a new Injector and assiciate it with this instance of the service
       const injector = new Injector(Base.providers);


### PR DESCRIPTION
- backport to v3 leaving out the test (as it would be just extra hassle if it was merged again with 4.0)