### PR TITLE
keep base name of decorated classes for better debugging

### DIFF
--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -26,6 +26,16 @@ it('should throw error if called in constructor', () => {
   }, 'BarService is either not injectable or a service is being called in the constructor.');
 });
 
+it('should throw error if static token is unavailable', () => {
+  assert.throws(() => {
+    const TOKEN = new StaticToken('test');
+
+    const parent = new Injector();
+
+    parent.inject(TOKEN);
+  }, 'Provider not found for "test"');
+});
+
 it('should use the calling injector as parent', () => {
   class FooService {
     value = '1';

--- a/packages/di/src/lib/inject.ts
+++ b/packages/di/src/lib/inject.ts
@@ -8,7 +8,7 @@ export function inject<This extends object, T>(token: InjectionToken<T>): Inject
     const injector = injectables.get(this);
 
     if (injector === undefined) {
-      const name = Object.getPrototypeOf(this.constructor).name;
+      const name = this.constructor.name;
 
       throw new Error(
         `${name} is either not injectable or a service is being called in the constructor. \n Either add the @injectable() to your class or use the @injected callback method.`

--- a/packages/di/src/lib/injectable-el.ts
+++ b/packages/di/src/lib/injectable-el.ts
@@ -5,45 +5,49 @@ export function injectableEl<T extends ConstructableToken<HTMLElement>>(
   Base: T,
   _ctx: ClassDecoratorContext
 ) {
-  return class InjectablElement extends Base {
-    constructor(..._: any[]) {
-      super();
+  const def = {
+    [Base.name]: class extends Base {
+      constructor(..._: any[]) {
+        super();
 
-      /**
-       * Listen for the finddiroot event.
-       * This is event is triggered when the element is connected to the dom
-       * This event will bubble up until it finds a parent injector which is then attached
-       * This will also work through shadow roots (that are not "closed")
-       */
-      this.addEventListener('finddiroot', (e) => {
-        e.stopPropagation();
+        /**
+         * Listen for the finddiroot event.
+         * This is event is triggered when the element is connected to the dom
+         * This event will bubble up until it finds a parent injector which is then attached
+         * This will also work through shadow roots (that are not "closed")
+         */
+        this.addEventListener('finddiroot', (e) => {
+          e.stopPropagation();
 
-        const parentInjector = findInjectorRoot(e);
+          const parentInjector = findInjectorRoot(e);
 
-        if (parentInjector) {
-          injectables.get(this)?.setParent(parentInjector);
-        }
-      });
-    }
+          if (parentInjector) {
+            injectables.get(this)?.setParent(parentInjector);
+          }
+        });
+      }
 
-    connectedCallback() {
-      if (this.isConnected) {
-        this.dispatchEvent(new Event('finddiroot', { bubbles: true, composed: true }));
+      connectedCallback() {
+        if (this.isConnected) {
+          this.dispatchEvent(new Event('finddiroot', { bubbles: true, composed: true }));
 
-        if (super.connectedCallback) {
-          super.connectedCallback();
+          if (super.connectedCallback) {
+            super.connectedCallback();
+          }
         }
       }
-    }
 
-    disconnectedCallback() {
-      injectables.get(this)?.setParent(undefined);
+      disconnectedCallback() {
+        injectables.get(this)?.setParent(undefined);
 
-      if (super.disconnectedCallback) {
-        super.disconnectedCallback();
+        if (super.disconnectedCallback) {
+          super.disconnectedCallback();
+        }
       }
     }
   };
+
+  return def[Base.name];
 }
 
 function findInjectorRoot(e: Event): Injector | null {

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -44,3 +44,12 @@ it('should inject the current service injectable instance', () => {
 
   assert.equal(service.injector(), injectables.get(service));
 });
+
+it('should not override the name of the original class', () => {
+  @injectable()
+  class MyService {
+    injector = inject(Injector);
+  }
+
+  assert.equal(MyService.name, 'MyService');
+});

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -13,28 +13,30 @@ export function injectable(opts?: InjectableOpts) {
     Base: T,
     ctx: ClassDecoratorContext
   ) {
-    class Injectable extends Base {
-      constructor(...args: any[]) {
-        super(...args);
+    const def = {
+      [Base.name]: class extends Base {
+        constructor(...args: any[]) {
+          super(...args);
 
-        const injector = new Injector(opts?.providers);
+          const injector = new Injector(opts?.providers);
 
-        injector.providers.push({
-          provide: Injector,
-          factory: () => injector
-        });
+          injector.providers.push({
+            provide: Injector,
+            factory: () => injector
+          });
 
-        injectables.set(this, injector);
+          injectables.set(this, injector);
+        }
       }
-    }
+    };
 
     // Only apply custom element bootstrap logic if the decorated class is an HTMLElement
     if ('HTMLElement' in globalThis) {
       if (HTMLElement.prototype.isPrototypeOf(Base.prototype)) {
-        return injectableEl(Injectable, ctx);
+        return injectableEl(def[Base.name], ctx);
       }
     }
 
-    return Injectable;
+    return def[Base.name];
   };
 }

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -82,7 +82,7 @@ export class Injector {
 
     if (token instanceof StaticToken) {
       if (!token.factory) {
-        throw new Error(`Provider not found for ${token}`);
+        throw new Error(`Provider not found for "${token.name}"`);
       }
 
       return this.#createAndCache(token, token.factory);


### PR DESCRIPTION
Currently when logging a decorated class you get something like "JoistElement" or "Injected" which can make debugging difficult. This PR dynamically names the class being returned from the various decorators to maintain the original decorated class name.

cc: @Phoscur 