### PR TITLE
Isolated modules and declarations

### DIFF
--- a/packages/di/src/lib/dom-injector.ts
+++ b/packages/di/src/lib/dom-injector.ts
@@ -1,11 +1,11 @@
 import { injectables, Injector } from './injector.js';
 
 export class DOMInjector extends Injector {
-  attach(root: HTMLElement) {
+  attach(root: HTMLElement): void {
     injectables.set(root, this);
   }
 
-  detach(root: HTMLElement) {
+  detach(root: HTMLElement): void {
     injectables.delete(root);
   }
 }

--- a/packages/di/src/lib/injectable-el.ts
+++ b/packages/di/src/lib/injectable-el.ts
@@ -4,7 +4,7 @@ import { ConstructableToken } from './provider.js';
 export function injectableEl<T extends ConstructableToken<HTMLElement>>(
   Base: T,
   _ctx: ClassDecoratorContext
-) {
+): T {
   const def = {
     [Base.name]: class extends Base {
       constructor(..._: any[]) {

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -12,7 +12,7 @@ export function injectable(opts?: InjectableOpts) {
   return function injectableDecorator<T extends ConstructableToken<any>>(
     Base: T,
     ctx: ClassDecoratorContext
-  ) {
+  ): T {
     const def = {
       [Base.name]: class extends Base {
         constructor(...args: any[]) {

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Keeps track of all Injectable services and their Injector
  */
-export const injectables = new WeakMap<object, Injector>();
+export const injectables: WeakMap<object, Injector> = new WeakMap();
 
 /**
  * Injectors create and store instances of services.
@@ -33,8 +33,8 @@ export class Injector {
   // keep track of instances. One Token can have one instance
   #instances = new WeakMap<InjectionToken<any>, any>();
 
-  parent;
-  providers;
+  parent?: Injector;
+  providers: Provider<unknown>[];
 
   constructor(providers: Provider<unknown>[] = [], parent?: Injector) {
     this.parent = parent;
@@ -91,11 +91,11 @@ export class Injector {
     return this.#createAndCache(token, () => new token());
   }
 
-  setParent(parent: Injector | undefined) {
+  setParent(parent: Injector | undefined): void {
     this.parent = parent;
   }
 
-  clear() {
+  clear(): void {
     this.#instances = new WeakMap();
   }
 

--- a/packages/di/src/lib/lifecycle.ts
+++ b/packages/di/src/lib/lifecycle.ts
@@ -1,9 +1,9 @@
-import { InjectableMetadata } from './metadata.js';
-
 (Symbol as any).metadata ??= Symbol('Symbol.metadata');
 
+import { InjectableMetadata } from './metadata.js';
+
 export function injected() {
-  return function onInjectDecorator(val: Function, ctx: ClassMethodDecoratorContext) {
+  return function onInjectDecorator(val: Function, ctx: ClassMethodDecoratorContext): void {
     const metadata: InjectableMetadata = ctx.metadata;
     metadata.onInjected ??= [];
     metadata.onInjected.push(val);
@@ -11,7 +11,7 @@ export function injected() {
 }
 
 export function created() {
-  return function onInjectDecorator(val: Function, ctx: ClassMethodDecoratorContext) {
+  return function onInjectDecorator(val: Function, ctx: ClassMethodDecoratorContext): void {
     const metadata: InjectableMetadata = ctx.metadata;
     metadata.onCreated ??= [];
     metadata.onCreated.push(val);

--- a/packages/di/src/lib/metadata.ts
+++ b/packages/di/src/lib/metadata.ts
@@ -5,7 +5,7 @@ export interface InjectableMetadata {
   onInjected?: Function[];
 }
 
-export function readMetadata<T>(target: ConstructableToken<T>) {
+export function readMetadata<T>(target: ConstructableToken<T>): InjectableMetadata | null {
   const metadata: InjectableMetadata | null = target[Symbol.metadata];
 
   return metadata;

--- a/packages/di/src/lib/provider.ts
+++ b/packages/di/src/lib/provider.ts
@@ -3,14 +3,14 @@ import { Injector } from './injector.js';
 export type ProviderFactory<T> = (injector: Injector) => T;
 
 export class StaticToken<T> {
-  #name;
-  #factory;
+  #name: string;
+  #factory?: ProviderFactory<T>;
 
-  get name() {
+  get name(): string {
     return this.#name;
   }
 
-  get factory() {
+  get factory(): ProviderFactory<T> | undefined {
     return this.#factory;
   }
 

--- a/packages/di/tsconfig.json
+++ b/packages/di/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "target"
+    "outDir": "target",
+    "isolatedDeclarations": true
   }
 }

--- a/packages/element/src/lib/attr-changed.ts
+++ b/packages/element/src/lib/attr-changed.ts
@@ -4,7 +4,7 @@ export function attrChanged(name: string) {
   return function attrChangedDecorator<This extends HTMLElement>(
     cb: Function,
     ctx: ClassMethodDecoratorContext<This>
-  ) {
+  ): void {
     const meta = metadataStore.read(ctx.metadata);
     const val = meta.attrChanges.get(name) ?? new Set();
 

--- a/packages/element/src/lib/element.ts
+++ b/packages/element/src/lib/element.ts
@@ -12,7 +12,7 @@ interface ElementConstructor {
 }
 
 export function element<T extends ElementConstructor>(opts?: ElementOpts) {
-  return function elementDecorator(Base: T, ctx: ClassDecoratorContext<T>) {
+  return function elementDecorator(Base: T, ctx: ClassDecoratorContext<T>): T {
     const meta = metadataStore.read(ctx.metadata);
 
     ctx.addInitializer(function () {

--- a/packages/element/src/lib/lifecycle.ts
+++ b/packages/element/src/lib/lifecycle.ts
@@ -1,7 +1,7 @@
 import { metadataStore } from './metadata.js';
 
 export function ready() {
-  return function readyDecorator(val: Function, ctx: ClassMethodDecoratorContext) {
+  return function readyDecorator(val: Function, ctx: ClassMethodDecoratorContext): void {
     const metadata = metadataStore.read(ctx.metadata);
 
     metadata.onReady.add(val);

--- a/packages/element/src/lib/listen.ts
+++ b/packages/element/src/lib/listen.ts
@@ -4,7 +4,10 @@ export function listen<This extends HTMLElement>(
   event: string,
   selector?: ListenerSelector<This> | string
 ) {
-  return function listenDecorator(value: (e: any) => void, ctx: ClassMethodDecoratorContext<This>) {
+  return function listenDecorator(
+    value: (e: any) => void,
+    ctx: ClassMethodDecoratorContext<This>
+  ): void {
     const metadata = metadataStore.read<This>(ctx.metadata);
 
     let selectorInternal: ListenerSelector<This> = (el) => el.shadowRoot ?? el;

--- a/packages/element/src/lib/metadata.ts
+++ b/packages/element/src/lib/metadata.ts
@@ -20,10 +20,10 @@ export class AttrMetadata extends Map<string, AttrDef> {}
 export class AttrChangeMetadata extends Map<string, Set<Function>> {}
 
 export class ElementMetadata<T> {
-  attrs = new AttrMetadata();
-  attrChanges = new AttrChangeMetadata();
+  attrs: AttrMetadata = new AttrMetadata();
+  attrChanges: AttrChangeMetadata = new AttrChangeMetadata();
   listeners: Listener<T>[] = [];
-  onReady = new Set<Function>();
+  onReady: Set<Function> = new Set();
 }
 
 export class MetadataStore extends WeakMap<object, ElementMetadata<unknown>> {
@@ -36,4 +36,4 @@ export class MetadataStore extends WeakMap<object, ElementMetadata<unknown>> {
   }
 }
 
-export const metadataStore = new MetadataStore();
+export const metadataStore: MetadataStore = new MetadataStore();

--- a/packages/element/src/lib/template.ts
+++ b/packages/element/src/lib/template.ts
@@ -15,7 +15,7 @@ export function template({ tokenPrefix = '#:', value }: TemplateOpts = {}) {
   // Track all nodes that can be updated and their associated property
   let updates: Updates | null = null;
 
-  return function render<T extends HTMLElement>(this: T, opts?: RenderOpts) {
+  return function render<T extends HTMLElement>(this: T, opts?: RenderOpts): void {
     if (!updates || opts?.refresh) {
       updates = findUpdates(this, {
         tokenPrefix,
@@ -105,7 +105,7 @@ function trackElement(node: Node, updates: Updates, opts: Required<TemplateOpts>
   return null;
 }
 
-export function getTemplateValue(obj: object, key: string) {
+export function getTemplateValue(obj: object, key: string): any {
   const parsed = key.split('.');
 
   let pointer: any = obj;

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "target"
+    "outDir": "target",
+    "isolatedDeclarations": true
   }
 }

--- a/packages/observable/src/lib/metadata.ts
+++ b/packages/observable/src/lib/metadata.ts
@@ -6,7 +6,7 @@ export class Changes<T> extends Map<keyof T, { oldValue: unknown; newValue: unkn
 
 export class ObservableInstanceMetadata<T> {
   scheduler: Promise<void> | null = null;
-  changes = new Changes<T>();
+  changes: Changes<T> = new Changes();
 }
 
 export class ObservableInstanceMetaDataStore extends WeakMap<
@@ -44,5 +44,7 @@ export class ObservableMetadataStore extends WeakMap<object, ObservableMetadata<
   }
 }
 
-export const instanceMetadataStore = new ObservableInstanceMetaDataStore();
-export const observableMetadataStore = new ObservableMetadataStore();
+export const instanceMetadataStore: ObservableInstanceMetaDataStore =
+  new ObservableInstanceMetaDataStore();
+
+export const observableMetadataStore: ObservableMetadataStore = new ObservableMetadataStore();

--- a/packages/observable/src/lib/observe.ts
+++ b/packages/observable/src/lib/observe.ts
@@ -54,7 +54,7 @@ export function effect() {
   return function effectDecorator<T extends object>(
     value: EffectFn<T>,
     ctx: ClassMethodDecoratorContext<T>
-  ) {
+  ): void {
     const data = observableMetadataStore.read<T>(ctx.metadata);
 
     data.effects.add(value);

--- a/packages/observable/tsconfig.json
+++ b/packages/observable/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "target"
+    "outDir": "target",
+    "isolatedDeclarations": true
   }
 }

--- a/packages/plugin-vite/tsconfig.json
+++ b/packages/plugin-vite/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "target"
+    "outDir": "target",
+    "isolatedDeclarations": true
   }
 }

--- a/packages/ssr/src/lib/applicator.ts
+++ b/packages/ssr/src/lib/applicator.ts
@@ -17,7 +17,7 @@ export class Applicator {
     this.#templateLoader = templateLoader;
   }
 
-  async apply(document: string, elements: string[]) {
+  async apply(document: string, elements: string[]): Promise<string> {
     const $ = load(document);
 
     return this.build($, elements);

--- a/packages/ssr/src/lib/template-cache.ts
+++ b/packages/ssr/src/lib/template-cache.ts
@@ -1,11 +1,11 @@
 export class TemplateCache {
   #cache = new Map<string, string>();
 
-  async get(key: string) {
+  async get(key: string): Promise<string | undefined> {
     return this.#cache.get(key);
   }
 
-  async set(key: string, val: string) {
+  async set(key: string, val: string): Promise<this> {
     this.#cache.set(key, val);
 
     return this;
@@ -13,11 +13,11 @@ export class TemplateCache {
 }
 
 export class NoopTemplateCache extends TemplateCache {
-  async get(_: string) {
+  async get(_: string): Promise<undefined> {
     return undefined;
   }
 
-  async set(_key: string, _val: string) {
+  async set(_key: string, _val: string): Promise<this> {
     return this;
   }
 }

--- a/packages/ssr/tsconfig.json
+++ b/packages/ssr/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "target"
+    "outDir": "target",
+    "isolatedDeclarations": true
   }
 }


### PR DESCRIPTION
TS has supported isolated modules and declarations for a while. These two options make it possible and easier for OTHER compilers to compile and generate both the js code and the .d.ts code.

This PR enables this for all packages so that we can be ready to use new buildtools when they become available

