### PR TITLE
add life-cyle callbacks for injectable custom elements

### DIFF
--- a/integration/hacker-news/src/components/news-feed.ts
+++ b/integration/hacker-news/src/components/news-feed.ts
@@ -1,5 +1,5 @@
 import { css, element, html } from '@joist/element';
-import { inject, injectable } from '@joist/di';
+import { inject, injectable, injected } from '@joist/di';
 
 import { HnService } from '../services/hn.service.js';
 import { HnNewsCard } from './news-card.js';
@@ -19,7 +19,8 @@ import { HnNewsCard } from './news-card.js';
 export class HnNewsFeed extends HTMLElement {
   #hn = inject(HnService);
 
-  async connectedCallback() {
+  @injected()
+  async onInjected() {
     const hn = this.#hn();
 
     const stories = await hn.getTopStories();

--- a/packages/di/src/lib/injectable-el.ts
+++ b/packages/di/src/lib/injectable-el.ts
@@ -1,10 +1,13 @@
 import { injectables, Injector } from './injector.js';
+import { readMetadata } from './metadata.js';
 import { ConstructableToken } from './provider.js';
 
 export function injectableEl<T extends ConstructableToken<HTMLElement>>(
   Base: T,
   _ctx: ClassDecoratorContext
 ): T {
+  const metadata = readMetadata(Base);
+
   const def = {
     [Base.name]: class extends Base {
       constructor(..._: any[]) {
@@ -24,6 +27,14 @@ export function injectableEl<T extends ConstructableToken<HTMLElement>>(
           if (parentInjector) {
             injectables.get(this)?.setParent(parentInjector);
           }
+
+          if (metadata) {
+            if (metadata.onCreated) {
+              for (let onCreated of metadata.onCreated) {
+                onCreated.call(this);
+              }
+            }
+          }
         });
       }
 
@@ -33,6 +44,14 @@ export function injectableEl<T extends ConstructableToken<HTMLElement>>(
 
           if (super.connectedCallback) {
             super.connectedCallback();
+          }
+
+          if (metadata) {
+            if (metadata.onInjected) {
+              for (let onInjected of metadata.onInjected) {
+                onInjected.call(this);
+              }
+            }
           }
         }
       }

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -1,3 +1,4 @@
+import { callLifecycle } from './lifecycle.js';
 import { readMetadata } from './metadata.js';
 import {
   ConstructableToken,
@@ -147,13 +148,5 @@ export class Injector {
     }
 
     return undefined;
-  }
-}
-
-function callLifecycle(instance: object, methods?: Function[]) {
-  if (methods) {
-    for (let cb of methods) {
-      cb.call(instance);
-    }
   }
 }

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -150,12 +150,10 @@ export class Injector {
   }
 }
 
-function callLifecycle(instance: object, methods?: unknown) {
-  if (Array.isArray(methods)) {
+function callLifecycle(instance: object, methods?: Function[]) {
+  if (methods) {
     for (let cb of methods) {
-      if (typeof cb === 'function') {
-        cb.call(instance);
-      }
+      cb.call(instance);
     }
   }
 }

--- a/packages/di/src/lib/lifecycle.ts
+++ b/packages/di/src/lib/lifecycle.ts
@@ -17,3 +17,11 @@ export function created() {
     metadata.onCreated.push(val);
   };
 }
+
+export function callLifecycle(instance: object, methods?: Function[]): void {
+  if (methods) {
+    for (let cb of methods) {
+      cb.call(instance);
+    }
+  }
+}


### PR DESCRIPTION
lifecycles are currently called by the injector itself. This means that custom elements do not have these lifecycles because they are not created from an injector. This PR makes the `injectableEl` decorator call all `onCreated` callbacks after the injector is set and all `onInjected` callbacks after connected
