### PR TITLE
allow injectable service to provide itself to a particular token

### DIFF
--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { injectable } from './injectable.js';
 import { inject } from './inject.js';
 import { injectables, Injector } from './injector.js';
+import { StaticToken } from './provider.js';
 
 it('should locally override a provider', () => {
   class Foo {}
@@ -50,4 +51,19 @@ it('should not override the name of the original class', () => {
   class MyService {}
 
   assert.equal(MyService.name, 'MyService');
+});
+
+it('should provide itself for spefified tokens', () => {
+  const TOKEN = new StaticToken('MY_TOKEN');
+
+  @injectable({
+    provideSelfAs: [TOKEN]
+  })
+  class MyService {
+    value = inject(TOKEN);
+  }
+
+  const service = new MyService();
+
+  assert.equal(service.value(), 'MyService');
 });

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -65,5 +65,5 @@ it('should provide itself for spefified tokens', () => {
 
   const service = new MyService();
 
-  assert.equal(service.value(), 'MyService');
+  assert.equal(service.value(), service);
 });

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -1,12 +1,13 @@
 (Symbol as any).metadata ??= Symbol('Symbol.metadata');
 
-import { ConstructableToken, Provider } from './provider.js';
+import { ConstructableToken, InjectionToken, Provider } from './provider.js';
 import { injectables, Injector } from './injector.js';
 import { injectableEl } from './injectable-el.js';
 
 export interface InjectableOpts {
   name?: string;
   providers?: Iterable<Provider<any>>;
+  provideSelfAs?: InjectionToken<any>[];
 }
 
 export function injectable(opts?: InjectableOpts) {
@@ -24,6 +25,14 @@ export function injectable(opts?: InjectableOpts) {
           injector.providers.set(Injector, {
             factory: () => injector
           });
+
+          if (opts?.provideSelfAs) {
+            for (const token of opts.provideSelfAs) {
+              injector.providers.set(token, {
+                factory: () => this
+              });
+            }
+          }
 
           injectables.set(this, injector);
         }


### PR DESCRIPTION
This will avoid users needing to manually push self to a token value.

```typescript
  const TOKEN = new StaticToken('MY_TOKEN');

  @injectable({
    provideSelfAs: [TOKEN]
  })
  class MyService {
    value = inject(TOKEN);
  }

  const service = new MyService();

  assert.equal(service.value(), 'MyService');
```