### PR TITLE
Fix test on windows

### DIFF
--- a/packages/ssr/src/lib/template-loader.test.ts
+++ b/packages/ssr/src/lib/template-loader.test.ts
@@ -18,6 +18,6 @@ it("FileSysTemplateLoader: should read from defined paths", async () => {
   const html = await loader.loadHTML("my-element");
   const css = await loader.loadCSS("my-element");
 
-  assert.equal(html?.trim(), "<h2>Hello World</h2>\n\n<slot></slot>");
-  assert.equal(css?.trim(), ":host {\n  display: flex;\n}");
+  assert.equal(html?.trim().replace(/\r\n/g, '\n'), "<h2>Hello World</h2>\n\n<slot></slot>");
+  assert.equal(css?.trim().replace(/\r\n/g, '\n'), ":host {\n  display: flex;\n}");
 });


### PR DESCRIPTION
- fix template loader linebreaks \r\n
<img width="820" height="1267" alt="grafik" src="https://github.com/user-attachments/assets/f5d2b910-c483-4dbd-a3a5-ebbac79cd8d8" />
