### PR TITLE
feat(di): delay attribute changed callbacks to run AFTER we have confirmed attachment

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -213,7 +213,10 @@ export class MyElement extends HTMLElement {
 
 ## AttrChanged Decorator
 
-The `@attrChanged` decorator allows you to easily register callback methods that are executed whenever specific observed attributes change. It is called during the custom element's standard `attributeChangedCallback`.
+The `@attrChanged` decorator allows you to easily register callback methods that are executed whenever specific observed attributes change.
+
+NOTE: method decorated with arrtChanged will not be called until after an element has been confirmed to be injected.
+This means this is the correct way to handle attribute changes if you are using an injected service.
 
 ```ts
 import { element, attr, attrChanged } from "@joist/element";
@@ -223,9 +226,28 @@ import { element, attr, attrChanged } from "@joist/element";
 })
 export class MyElement extends HTMLElement {
   @attr()
-  accessor greeting = "Hello World";
+  accessor name = "Danny Blue";
 
-  @attrChanged("greeting")
+  @attr()
+  accessor age = 37;
+
+  @attr()
+  accessor DOB = "1/1/1988";
+
+  // run when this one attribute changes
+  @attrChanged("name")
+  onGreetingChanged(name: string, oldValue: string, newValue: string) {
+    console.log(`Attribute ${name} changed from "${oldValue}" to "${newValue}"`);
+  }
+
+  // run when any of the following change
+  @attrChanged("name", "age")
+  onGreetingChanged(name: string, oldValue: string, newValue: string) {
+    console.log(`Attribute ${name} changed from "${oldValue}" to "${newValue}"`);
+  }
+
+  // run when an attribute change matches the RegExp
+  @attrChanged(/.*/)
   onGreetingChanged(name: string, oldValue: string, newValue: string) {
     console.log(`Attribute ${name} changed from "${oldValue}" to "${newValue}"`);
   }

--- a/packages/element/src/lib/attr-changed.test.ts
+++ b/packages/element/src/lib/attr-changed.test.ts
@@ -1,10 +1,12 @@
 import { assert } from "chai";
+import { injectable, inject } from "@joist/di";
+import { fixtureSync, html } from "@open-wc/testing";
 
 import { attrChanged } from "./attr-changed.js";
 import { attr } from "./attr.js";
 import { element } from "./element.js";
 
-it("should call specific attrbute callback", () => {
+it("should call specific attrbute callback", async () => {
   let args: string[] = [];
 
   @element({
@@ -24,16 +26,20 @@ it("should call specific attrbute callback", () => {
 
   document.body.append(el);
 
+  await Promise.resolve();
+
   assert.deepEqual(args, ["test", null, "hello"]);
 
   el.setAttribute("test", "world");
+
+  await Promise.resolve();
 
   assert.deepEqual(args, ["test", "hello", "world"]);
 
   el.remove();
 });
 
-it("should call callback for multiple attributes", () => {
+it("should call callback for multiple attributes", async () => {
   const args: string[][] = [];
 
   @element({
@@ -56,12 +62,16 @@ it("should call callback for multiple attributes", () => {
 
   document.body.append(el);
 
+  await Promise.resolve();
+
   assert.deepEqual(args, [
     ["test1", null, "hello"],
     ["test2", null, "world"],
   ]);
 
   el.setAttribute("test1", "world");
+
+  await Promise.resolve();
 
   assert.deepEqual(args, [
     ["test1", null, "hello"],
@@ -70,4 +80,60 @@ it("should call callback for multiple attributes", () => {
   ]);
 
   el.remove();
+});
+
+it("should not trigger callback until the element has been attached and given an injector", async () => {
+  @injectable()
+  class Logger {
+    log(arg: string) {
+      throw new Error("Not implemented");
+    }
+  }
+
+  @element({
+    tagName: "app-logger",
+    provideSelfAs: [Logger],
+  })
+  class LoggerElement extends HTMLElement implements Logger {
+    logs: string[] = [];
+
+    log(message: any) {
+      this.logs.push(message);
+    }
+  }
+
+  @element({
+    tagName: "attr-changed-3",
+  })
+  class MyElement extends HTMLElement {
+    #logger = inject(Logger);
+
+    @attr()
+    accessor test1 = "hello";
+
+    @attr()
+    accessor test2 = "world";
+
+    @attrChanged("test1", "test2")
+    onTestChanged(attr: string, oldValue: string, newValue: string) {
+      const logger = this.#logger();
+
+      logger.log(`${attr}:${oldValue}:${newValue}`);
+    }
+  }
+
+  const testbed = fixtureSync<LoggerElement>(html`
+    <app-logger>
+      <attr-changed-3></attr-changed-3>
+    </app-logger>
+  `);
+
+  const el = testbed.querySelector<MyElement>("attr-changed-3");
+
+  assert.isNotNull(testbed);
+  assert.isNotNull(el);
+
+  await Promise.resolve();
+
+  assert.deepEqual(testbed.logs, ["test1:null:hello", "test2:null:world"]);
 });

--- a/packages/element/src/lib/attr-changed.test.ts
+++ b/packages/element/src/lib/attr-changed.test.ts
@@ -6,11 +6,19 @@ import { attrChanged } from "./attr-changed.js";
 import { attr } from "./attr.js";
 import { element } from "./element.js";
 
+let counter = 0;
+let tagName = `attr-changed-${counter}`;
+
+beforeEach(() => {
+  tagName = `attr-changed-${counter++}`;
+  console.log(`tagName: ${tagName}`);
+});
+
 it("should call specific attrbute callback", async () => {
   let args: string[] = [];
 
   @element({
-    tagName: "attr-changed-1",
+    tagName,
   })
   class MyElement extends HTMLElement {
     @attr()
@@ -43,7 +51,7 @@ it("should call callback for multiple attributes", async () => {
   const args: string[][] = [];
 
   @element({
-    tagName: "attr-changed-2",
+    tagName,
   })
   class MyElement extends HTMLElement {
     @attr()
@@ -103,7 +111,7 @@ it("should not trigger callback until the element has been attached and given an
   }
 
   @element({
-    tagName: "attr-changed-3",
+    tagName,
   })
   class MyElement extends HTMLElement {
     #logger = inject(Logger);
@@ -124,11 +132,13 @@ it("should not trigger callback until the element has been attached and given an
 
   const testbed = fixtureSync<LoggerElement>(html`
     <app-logger>
-      <attr-changed-3></attr-changed-3>
+      <attr-changed-2></attr-changed-2>
     </app-logger>
   `);
 
-  const el = testbed.querySelector<MyElement>("attr-changed-3");
+  console.log(testbed);
+
+  const el = testbed.querySelector<MyElement>(tagName);
 
   assert.isNotNull(testbed);
   assert.isNotNull(el);
@@ -136,4 +146,37 @@ it("should not trigger callback until the element has been attached and given an
   await Promise.resolve();
 
   assert.deepEqual(testbed.logs, ["test1:null:hello", "test2:null:world"]);
+});
+
+it("should call specific attrbute callback that uses RegExp", async () => {
+  let args: string[][] = [];
+
+  @element({
+    tagName,
+  })
+  class MyElement extends HTMLElement {
+    @attr()
+    accessor test_1 = "hello";
+
+    @attr()
+    accessor test_2 = "world";
+
+    @attrChanged(/test_.*/)
+    onTestChanged(name: string, oldValue: string, newValue: string) {
+      args.push([name, oldValue, newValue]);
+    }
+  }
+
+  const el = new MyElement();
+
+  document.body.append(el);
+
+  await Promise.resolve();
+
+  assert.deepEqual(args, [
+    ["test_1", null, "hello"],
+    ["test_2", null, "world"],
+  ]);
+
+  el.remove();
 });

--- a/packages/element/src/lib/attr-changed.test.ts
+++ b/packages/element/src/lib/attr-changed.test.ts
@@ -11,7 +11,6 @@ let tagName = `attr-changed-${counter}`;
 
 beforeEach(() => {
   tagName = `attr-changed-${counter++}`;
-  console.log(`tagName: ${tagName}`);
 });
 
 it("should call specific attrbute callback", async () => {

--- a/packages/element/src/lib/attr-changed.ts
+++ b/packages/element/src/lib/attr-changed.ts
@@ -1,6 +1,6 @@
-import { type AttrChangedCallback, metadataStore } from "./metadata.js";
+import { type AttrChangedCallback, type AttrMatcher, metadataStore } from "./metadata.js";
 
-export function attrChanged(...names: string[]) {
+export function attrChanged(...names: AttrMatcher[]) {
   return function attrChangedDecorator<This extends HTMLElement>(
     cb: AttrChangedCallback,
     ctx: ClassMethodDecoratorContext<This>,

--- a/packages/element/src/lib/element.ts
+++ b/packages/element/src/lib/element.ts
@@ -33,7 +33,7 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
       }
 
       #abortController: AbortController | null = null;
-      #injected = withProviders();
+      #injected = asyncWithProviders();
 
       constructor(...args: any[]) {
         super(...args);
@@ -131,7 +131,7 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
       }
 
       disconnectedCallback(): void {
-        this.#injected = withProviders();
+        this.#injected = asyncWithProviders();
 
         if (this.#abortController) {
           this.#abortController.abort();
@@ -176,7 +176,7 @@ function reflectAttributeValues<T extends HTMLElement>(el: T, attrs: AttrMetadat
   }
 }
 
-function withProviders<T = void>(): {
+function asyncWithProviders<T = void>(): {
   promise: Promise<T>;
   resolve: (...args: any[]) => void;
   reject: () => void;

--- a/packages/element/src/lib/element.ts
+++ b/packages/element/src/lib/element.ts
@@ -1,4 +1,4 @@
-import { injectable, type InjectableOpts } from "@joist/di";
+import { injectable, injected, type InjectableOpts } from "@joist/di";
 
 import { define } from "./define.js";
 import type { DefineOpts } from "./define.js";
@@ -33,6 +33,7 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
       }
 
       #abortController: AbortController | null = null;
+      #injected = withProviders();
 
       constructor(...args: any[]) {
         super(...args);
@@ -52,7 +53,7 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
         }
       }
 
-      attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+      async attributeChangedCallback(name: string, oldValue: string, newValue: string) {
         const attr = meta.attrs.get(name);
         const cbs = meta.attrChanges.get(name);
 
@@ -84,18 +85,25 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
             attr.access.set.call(this, value);
           }
 
-          if (cbs) {
-            for (const cb of cbs) {
-              cb.call(this, name, oldValue, newValue);
-            }
-          }
-
           if (attr.observe) {
             if (super.attributeChangedCallback) {
               super.attributeChangedCallback(name, oldValue, newValue);
             }
           }
+
+          await this.#injected.promise;
+
+          if (cbs) {
+            for (const cb of cbs) {
+              cb.call(this, name, oldValue, newValue);
+            }
+          }
         }
+      }
+
+      @injected()
+      __isInjected() {
+        this.#injected.resolve();
       }
 
       connectedCallback() {
@@ -123,6 +131,8 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
       }
 
       disconnectedCallback(): void {
+        this.#injected = withProviders();
+
         if (this.#abortController) {
           this.#abortController.abort();
           this.#abortController = null;
@@ -164,4 +174,24 @@ function reflectAttributeValues<T extends HTMLElement>(el: T, attrs: AttrMetadat
       }
     }
   }
+}
+
+function withProviders<T = void>(): {
+  promise: Promise<T>;
+  resolve: (...args: any[]) => void;
+  reject: () => void;
+} {
+  let providerResolve: ((...args: any[]) => void) | null = null;
+  let providerReject: (() => void) | null = null;
+
+  const promise = new Promise<T>((resolve, reject) => {
+    providerResolve = resolve;
+    providerReject = reject;
+  });
+
+  if (providerReject === null || providerResolve === null) {
+    throw new Error(`Something has gone wrong when constructing the promise`);
+  }
+
+  return { promise, resolve: providerResolve, reject: providerReject };
 }

--- a/packages/element/src/lib/element.ts
+++ b/packages/element/src/lib/element.ts
@@ -55,7 +55,6 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
 
       async attributeChangedCallback(name: string, oldValue: string, newValue: string) {
         const attr = meta.attrs.get(name);
-        const cbs = meta.attrChanges.get(name);
 
         if (attr) {
           if (oldValue !== newValue) {
@@ -93,9 +92,17 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
 
           await this.#injected.promise;
 
-          if (cbs) {
-            for (const cb of cbs) {
-              cb.call(this, name, oldValue, newValue);
+          for (const [matcher, callbacks] of meta.attrChanges) {
+            if (typeof matcher === "string") {
+              if (matcher === name) {
+                for (const cb of callbacks) {
+                  cb.call(this, name, oldValue, newValue);
+                }
+              }
+            } else if (matcher.test(name)) {
+              for (const cb of callbacks) {
+                cb.call(this, name, oldValue, newValue);
+              }
             }
           }
         }

--- a/packages/element/src/lib/element.ts
+++ b/packages/element/src/lib/element.ts
@@ -5,6 +5,8 @@ import type { DefineOpts } from "./define.js";
 import { type AttrMetadata, metadataStore } from "./metadata.js";
 import type { ShadowResult } from "./result.js";
 
+const IsInjected: unique symbol = Symbol("isInjected");
+
 export interface ElementOpts extends Partial<DefineOpts>, InjectableOpts {
   shadowDom?: ShadowResult[];
   shadowDomOpts?: ShadowRootInit;
@@ -109,7 +111,7 @@ export function element<T extends ElementConstructor>(opts?: ElementOpts) {
       }
 
       @injected()
-      __isInjected() {
+      [IsInjected]() {
         this.#injected.resolve();
       }
 

--- a/packages/element/src/lib/metadata.ts
+++ b/packages/element/src/lib/metadata.ts
@@ -22,9 +22,9 @@ export interface Listener<T> {
 }
 
 export type AttrChangedCallback = (name: string, oldValue: string, newValue: string) => void;
-
+export type AttrMatcher = string | RegExp;
 export class AttrMetadata extends Map<string, AttrDef> {}
-export class AttrChangeMetadata extends Map<string, Set<AttrChangedCallback>> {}
+export class AttrChangeMetadata extends Map<AttrMatcher, Set<AttrChangedCallback>> {}
 
 export class ElementMetadata<T> {
   attrs: AttrMetadata = new AttrMetadata();


### PR DESCRIPTION
This Pull Request changes how attribute changes are handled. The custom @attrChanged decorator will now not fire until after an element has been attached to an injector. This solve an annoying problem where attrChanged callbacks can fire before you are ready.

closes #1276